### PR TITLE
Added stalls for market 2, added filtering to market screens, enhanced the market screens design

### DIFF
--- a/seng303-lab-2-reference-implementation/app/build.gradle.kts
+++ b/seng303-lab-2-reference-implementation/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.navigation:navigation-compose:2.6.0")
+    implementation("androidx.wear.compose:compose-material:1.4.0")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
@@ -72,5 +73,9 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     implementation("com.google.code.gson:gson:2.8.9")
     implementation("io.insert-koin:koin-android:3.1.4")
+
+    implementation("androidx.compose.material:material-icons-extended")
+
+
 
 }

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/MainActivity.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/MainActivity.kt
@@ -1,5 +1,6 @@
 package nz.ac.canterbury.seng303.lab2
 
+import AllStallsScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -23,7 +24,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import nz.ac.canterbury.seng303.lab2.screens.StallScreen
-import nz.ac.canterbury.seng303.lab2.screens.AllStallsScreen
+//import nz.ac.canterbury.seng303.lab2.screens.AllStallsScreen
 import nz.ac.canterbury.seng303.lab2.ui.theme.Lab1Theme
 import nz.ac.canterbury.seng303.lab2.viewmodels.StallViewModel // Import StallViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel as koinViewModel
@@ -124,9 +125,6 @@ fun Home(navController: NavController, stallViewModel: StallViewModel) {
             navController = navController,
             stallViewModel = stallViewModel
         )
-
-
-
 
     }
 }

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/datastore/Storage.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/datastore/Storage.kt
@@ -2,6 +2,7 @@ package nz.ac.canterbury.seng303.lab2.datastore
 
 import kotlinx.coroutines.flow.Flow
 import nz.ac.canterbury.seng303.lab2.models.Identifiable
+import nz.ac.canterbury.seng303.lab2.models.Market1Stalls
 
 interface Storage<T> where T : Identifiable {
     fun insert(data: T): Flow<Int>
@@ -10,4 +11,6 @@ interface Storage<T> where T : Identifiable {
     fun delete(identifier: Int): Flow<Int>
     fun edit(identifier: Int, data: T): Flow<Int>
     fun get(where: (T) -> Boolean): Flow<T>
+    fun getCategories(marketId: Int): Flow<List<String>>
+    fun getStallByName(marketId: Int, stallName: String): Flow<Identifiable?>
 }

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/models/Market2Stalls.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/models/Market2Stalls.kt
@@ -111,6 +111,287 @@ class Market2Stalls(
                         Product(50, "Catfish", "Fried catfish", 8.0)
                     ),
                     R.drawable.stall_fresh_catch
+                ),
+                Market2Stalls(
+                    6,
+                    "Ocean's Bounty",
+                    "Seafood",
+                    listOf(
+                        Product(51, "Oysters", "Fresh oysters on the half shell", 15.0),
+                        Product(52, "Clams", "Steamed clams with garlic butter", 10.0),
+                        Product(53, "Calamari", "Crispy fried calamari", 12.0),
+                        Product(54, "Seaweed", "Fresh seaweed salad", 7.0),
+                        Product(55, "Fish Tacos", "Tacos filled with grilled fish", 8.0),
+                        Product(56, "Crab Cakes", "Crispy crab cakes", 10.0),
+                        Product(
+                            57,
+                            "Shrimp Cocktail",
+                            "Chilled shrimp with cocktail sauce",
+                            12.0
+                        ),
+                        Product(58, "Seafood Paella", "Mixed seafood rice dish", 14.0),
+                        Product(59, "Fish & Chips", "Classic fish and chips", 11.0),
+                        Product(60, "Clam Chowder", "Creamy clam chowder", 6.0)
+                    ),
+                    R.drawable.stall_oceans_bounty
+                ),
+                Market2Stalls(
+                    7,
+                    "Tea Time",
+                    "Tea",
+                    listOf(
+                        Product(61, "Green Tea", "Refreshing green tea", 2.0),
+                        Product(62, "Herbal Tea", "Calming herbal blends", 2.5),
+                        Product(63, "Black Tea", "Rich black tea", 2.0),
+                        Product(64, "Chai Tea", "Spiced chai tea", 3.0),
+                        Product(65, "Iced Tea", "Chilled tea with lemon", 2.5),
+                        Product(66, "Matcha Latte", "Smooth matcha latte", 4.0),
+                        Product(67, "Tea Accessories", "Tea pots and cups", 5.0),
+                        Product(68, "Loose Leaf Tea", "Premium loose leaf tea", 4.5),
+                        Product(69, "Flavored Tea", "Variety of flavored teas", 3.5),
+                        Product(70, "Tea Infuser", "Infuser for loose leaf tea", 2.0)
+                    ),
+                    R.drawable.stall_tea_time
+                ),
+                Market2Stalls(
+                    8,
+                    "Farm Fresh Eggs",
+                    "Eggs",
+                    listOf(
+                        Product(71, "Free-range Eggs", "Fresh free-range eggs", 3.0),
+                        Product(72, "Egg-based Products", "Various egg-based products", 4.0),
+                        Product(73, "Egg Salad", "Delicious egg salad", 5.0),
+                        Product(74, "Quiche", "Savory egg quiche", 6.0),
+                        Product(75, "Deviled Eggs", "Classic deviled eggs", 4.5),
+                        Product(76, "Egg Muffins", "Egg muffins with veggies", 5.0),
+                        Product(77, "Pickled Eggs", "Pickled eggs for snacking", 3.5),
+                        Product(78, "Omelet Mix", "Mix for homemade omelets", 2.5),
+                        Product(79, "Egg Noodles", "Fresh egg noodles", 4.0),
+                        Product(80, "Egg Drop Soup", "Egg drop soup", 3.0)
+                    ),
+                    R.drawable.stall_farm_fresh_eggs
+                ),
+                Market2Stalls(
+                    9,
+                    "Olive Orchard",
+                    "Olives",
+                    listOf(
+                        Product(81, "Extra Virgin Olive Oil", "High-quality olive oil", 10.0),
+                        Product(
+                            82,
+                            "Stuffed Olives",
+                            "Delicious olives stuffed with herbs",
+                            5.0
+                        ),
+                        Product(83, "Olive Tapenade", "Savory olive spread", 6.0),
+                        Product(84, "Marinated Olives", "Flavorful marinated olives", 4.0),
+                        Product(85, "Olive Bruschetta", "Bruschetta with olives", 5.0),
+                        Product(86, "Olive Oil Infused", "Olive oil infused with herbs", 8.0),
+                        Product(87, "Olive Pesto", "Pesto made with olives", 6.0),
+                        Product(88, "Green Olives", "Crisp green olives", 4.0),
+                        Product(89, "Black Olives", "Savory black olives", 4.0),
+                        Product(90, "Olive-based Snacks", "Snacks made with olives", 5.0)
+                    ),
+                    R.drawable.stall_olive_orchard
+                ),
+                Market2Stalls(
+                    10,
+                    "Sweet Treats",
+                    "Bakery",
+                    listOf(
+                        Product(91, "Croissants", "Flaky butter croissants", 3.0),
+                        Product(92, "Cookies", "Homemade cookies", 2.0),
+                        Product(93, "Brownies", "Rich chocolate brownies", 2.5),
+                        Product(94, "Cupcakes", "Decorated cupcakes", 3.5),
+                        Product(95, "Cheesecake", "Creamy cheesecake", 4.0),
+                        Product(96, "Danish Pastries", "Flaky danish pastries", 3.5),
+                        Product(97, "Tarts", "Fruit tarts", 4.5),
+                        Product(98, "Pies", "Assorted fruit pies", 5.0),
+                        Product(99, "Meringues", "Light meringues", 2.5),
+                        Product(100, "Macarons", "Colorful French macarons", 3.5)
+                    ),
+                    R.drawable.stall_sweet_treats
+                ),
+                Market2Stalls(
+                    11,
+                    "Zvolskiy Delights",
+                    "Bakery",
+                    listOf(
+                        Product(101, "Baked Goods", "Local specialties and baked goods", 4.0),
+                        Product(102, "Sourdough Bread", "Artisan sourdough bread", 4.5),
+                        Product(103, "Pita Bread", "Freshly baked pita bread", 3.0),
+                        Product(104, "Flatbread", "Soft flatbread", 2.5),
+                        Product(105, "Breadsticks", "Crispy breadsticks", 3.0),
+                        Product(106, "Rolls", "Fresh dinner rolls", 2.0),
+                        Product(107, "Focaccia", "Herb-infused focaccia", 4.0),
+                        Product(108, "Bagels", "Freshly baked bagels", 3.0),
+                        Product(109, "Brioche", "Soft brioche bread", 3.5),
+                        Product(110, "Ciabatta", "Italian ciabatta bread", 4.0)
+                    ),
+                    R.drawable.stall_zvolskiy_delights
+                ),
+                Market2Stalls(
+                    12,
+                    "Donad's Bakery",
+                    "Bakery",
+                    listOf(
+                        Product(111, "Bread", "Freshly baked bread", 2.5),
+                        Product(112, "Pastries", "Delicious pastries", 3.0),
+                        Product(113, "Tarts", "Sweet and savory tarts", 4.5),
+                        Product(114, "Cookies", "Freshly baked cookies", 2.0),
+                        Product(115, "Muffins", "Fluffy muffins", 3.0),
+                        Product(116, "Cinnamon Rolls", "Warm cinnamon rolls", 4.0),
+                        Product(117, "Danish", "Fruit danish pastries", 3.5),
+                        Product(118, "Cakes", "Homemade cakes", 5.0),
+                        Product(119, "Cupcakes", "Decorated cupcakes", 4.0),
+                        Product(120, "Biscotti", "Crunchy biscotti", 2.5)
+                    ),
+                    R.drawable.stall_donads_bakery
+                ),
+                Market2Stalls(
+                    13,
+                    "Artisan Breads",
+                    "Breads",
+                    listOf(
+                        Product(121, "Sourdough", "Artisan sourdough bread", 4.0),
+                        Product(122, "Baguettes", "Fresh baguettes", 2.5),
+                        Product(123, "Whole Wheat Bread", "Nutritious whole wheat bread", 3.0),
+                        Product(124, "Multigrain Bread", "Healthy multigrain bread", 3.5),
+                        Product(125, "Rye Bread", "Traditional rye bread", 3.0),
+                        Product(126, "Flatbread", "Soft flatbread", 2.5),
+                        Product(127, "Pita Bread", "Freshly baked pita bread", 3.0),
+                        Product(128, "Focaccia", "Herb-infused focaccia", 4.0),
+                        Product(129, "Dinner Rolls", "Soft dinner rolls", 2.0),
+                        Product(130, "Breadsticks", "Crispy breadsticks", 2.5)
+                    ),
+                    R.drawable.stall_artisan_bakery
+                ),
+                Market2Stalls(
+                    14,
+                    "Veggie Haven",
+                    "Vegetables",
+                    listOf(
+                        Product(131, "Organic Vegetables", "Fresh organic vegetables", 5.0),
+                        Product(132, "Salad Mix", "Fresh salad greens", 4.0),
+                        Product(133, "Herbs", "Fresh herbs for cooking", 2.0),
+                        Product(134, "Root Vegetables", "Seasonal root vegetables", 3.0),
+                        Product(135, "Peppers", "Assorted peppers", 2.5),
+                        Product(136, "Tomatoes", "Fresh tomatoes", 2.0),
+                        Product(137, "Cucumbers", "Crisp cucumbers", 1.5),
+                        Product(138, "Zucchini", "Fresh zucchini", 2.0),
+                        Product(139, "Carrots", "Sweet carrots", 2.0),
+                        Product(140, "Eggplant", "Fresh eggplant", 3.0)
+                    ),
+                    R.drawable.stall_vegie_haven
+                ),
+                Market2Stalls(
+                    15,
+                    "Berry Bliss",
+                    "Berries",
+                    listOf(
+                        Product(141, "Strawberries", "Fresh strawberries", 3.5),
+                        Product(142, "Blueberries", "Fresh blueberries", 4.0),
+                        Product(143, "Raspberries", "Sweet raspberries", 5.0),
+                        Product(144, "Blackberries", "Juicy blackberries", 4.5),
+                        Product(145, "Gooseberries", "Tart gooseberries", 4.0),
+                        Product(146, "Mixed Berries", "Assorted fresh berries", 5.0),
+                        Product(147, "Berry Jam", "Homemade berry jam", 6.0),
+                        Product(148, "Berry Smoothies", "Delicious berry smoothies", 4.5),
+                        Product(149, "Dried Berries", "Dried mixed berries", 5.0),
+                        Product(150, "Berry Desserts", "Assorted berry desserts", 6.0)
+                    ),
+                    R.drawable.stall_berry_bliss
+                ),
+                Market2Stalls(
+                    16,
+                    "Fruity Fiesta",
+                    "Fruits",
+                    listOf(
+                        Product(151, "Apples", "Crisp apples", 2.0),
+                        Product(152, "Oranges", "Juicy oranges", 2.5),
+                        Product(153, "Bananas", "Fresh bananas", 1.5),
+                        Product(154, "Pineapples", "Sweet pineapples", 3.0),
+                        Product(155, "Mangoes", "Ripe mangoes", 3.5),
+                        Product(156, "Grapes", "Fresh grapes", 4.0),
+                        Product(157, "Peaches", "Juicy peaches", 3.0),
+                        Product(158, "Cherries", "Fresh cherries", 4.5),
+                        Product(159, "Kiwi", "Exotic kiwi fruit", 2.5),
+                        Product(160, "Watermelon", "Refreshing watermelon", 3.5)
+                    ),
+                    R.drawable.stall_fruity_fiesta
+                ),
+                Market2Stalls(
+                    17,
+                    "Veggie Patch",
+                    "Vegetables",
+                    listOf(
+                        Product(131, "Organic Carrots", "Fresh organic carrots", 1.5),
+                        Product(132, "Tomatoes", "Juicy tomatoes", 2.0),
+                        Product(133, "Cucumbers", "Crisp cucumbers", 1.0),
+                        Product(134, "Zucchini", "Fresh zucchini", 2.5),
+                        Product(135, "Bell Peppers", "Colorful bell peppers", 1.5),
+                        Product(136, "Lettuce", "Fresh lettuce for salads", 1.0),
+                        Product(137, "Spinach", "Organic spinach", 2.0),
+                        Product(138, "Herbs", "Fresh herbs for cooking", 1.0),
+                        Product(139, "Eggplant", "Fresh eggplant", 2.0),
+                        Product(140, "Pumpkins", "Seasonal pumpkins", 3.0)
+                    ),
+                    R.drawable.stall_vegie_patch
+                ),
+                Market2Stalls(
+                    17,
+                    "Cheese Corner",
+                    "Cheese",
+                    listOf(
+                        Product(101, "Cheddar", "Sharp cheddar cheese", 5.0),
+                        Product(102, "Brie", "Creamy brie cheese", 7.0),
+                        Product(103, "Gouda", "Aged gouda cheese", 6.0),
+                        Product(104, "Feta", "Crumbly feta cheese", 4.0),
+                        Product(105, "Mozzarella", "Fresh mozzarella cheese", 5.5),
+                        Product(106, "Blue Cheese", "Tangy blue cheese", 8.0),
+                        Product(107, "Parmesan", "Grated parmesan cheese", 6.5),
+                        Product(108, "Goat Cheese", "Soft goat cheese", 6.0),
+                        Product(109, "Ricotta", "Creamy ricotta cheese", 4.5),
+                        Product(110, "Cream Cheese", "Smooth cream cheese", 3.0)
+                    ),
+                    R.drawable.stall_cheese_corner
+                ),
+                Market2Stalls(
+                    18,
+                    "Burger Bliss",
+                    "Burgers",
+                    listOf(
+                        Product(111, "Beef Burger", "Juicy beef burger", 8.0),
+                        Product(112, "Veggie Burger", "Delicious veggie burger", 7.0),
+                        Product(113, "Cheeseburger", "Beef burger with cheese", 9.0),
+                        Product(114, "Bacon Burger", "Beef burger with bacon", 10.0),
+                        Product(115, "Chicken Burger", "Grilled chicken burger", 9.5),
+                        Product(116, "BBQ Burger", "BBQ sauce beef burger", 9.0),
+                        Product(117, "Mushroom Burger", "Beef burger with mushrooms", 9.0),
+                        Product(118, "Double Burger", "Double beef patty burger", 11.0),
+                        Product(119, "Spicy Burger", "Spicy beef burger", 9.0),
+                        Product(120, "Fish Burger", "Crispy fish burger", 8.5)
+                    ),
+                    R.drawable.stall_burger_bliss
+                ),
+
+                Market2Stalls(
+                    20,
+                    "Jammin' Good",
+                    "Jams",
+                    listOf(
+                        Product(131, "Strawberry Jam", "Sweet strawberry jam", 3.0),
+                        Product(132, "Blueberry Jam", "Delicious blueberry jam", 4.0),
+                        Product(133, "Raspberry Jam", "Tart raspberry jam", 3.5),
+                        Product(134, "Apricot Jam", "Fruity apricot jam", 2.5),
+                        Product(135, "Orange Marmalade", "Zesty orange marmalade", 3.5),
+                        Product(136, "Peach Preserves", "Sweet peach preserves", 4.0),
+                        Product(137, "Mixed Berry Jam", "Assorted berry jam", 4.0),
+                        Product(138, "Honey Jam", "Natural honey jam", 3.5),
+                        Product(139, "Fig Jam", "Rich fig jam", 4.5),
+                        Product(140, "Ginger Jam", "Spicy ginger jam", 3.5)
+                    ),
+                    R.drawable.stall_jammin_good
                 )
 
             )

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/screens/AllStallsScreen.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/screens/AllStallsScreen.kt
@@ -1,31 +1,22 @@
-package nz.ac.canterbury.seng303.lab2.screens
-
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -34,126 +25,265 @@ import nz.ac.canterbury.seng303.lab2.models.Identifiable
 import nz.ac.canterbury.seng303.lab2.models.Market1Stalls
 import nz.ac.canterbury.seng303.lab2.models.Market2Stalls
 import nz.ac.canterbury.seng303.lab2.viewmodels.StallViewModel
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.foundation.border
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.runtime.saveable.rememberSaveable
 
 @Composable
 fun AllStallsScreen(navController: NavController, stallViewModel: StallViewModel, marketId: Int?) {
-    Log.d("YourTag", "This is a debug message $marketId")
-
-    // Fetch the stalls when the screen is first composed
-    LaunchedEffect(marketId) {
-        stallViewModel.getStalls(marketId)
-    }
-
-    // Collect the stalls from the ViewModel as a general Identifiable type
+    var selectedCategory by rememberSaveable { mutableStateOf("Categories") }
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    val categories by stallViewModel.categories.collectAsState(initial = emptyList())
     val stalls: List<Identifiable> by stallViewModel.stalls.collectAsState(emptyList())
-
-    LazyVerticalGrid(
-        columns = GridCells.Fixed(2), // Specify the number of columns in the grid
-        contentPadding = PaddingValues(4.dp, 8.dp),
-        modifier = Modifier.background(Color.LightGray)
+    val updatedCategories = listOf("Categories") + categories
+    // Trigger fetching of categories when the screen is loaded
+    LaunchedEffect(marketId) {
+        if (marketId != null) {
+            stallViewModel.getStalls(marketId)
+            stallViewModel.getStallCategories(marketId)
+        }
+    }
+    LaunchedEffect(categories) {
+        // Log or debug output to verify the categories
+        println("Fetched categories for marketId $marketId: $categories")
+    }
+    // Filter stalls based on selected category and search query
+    val filteredStalls = stalls.filter { stall ->
+        when (stall) {
+            is Market1Stalls -> {
+                (selectedCategory == "Categories" || stall.category == selectedCategory) &&
+                        (searchQuery.isEmpty() || stall.name.contains(searchQuery, ignoreCase = true))
+            }
+            is Market2Stalls -> {
+                (selectedCategory == "Categories" || stall.category == selectedCategory) &&
+                        (searchQuery.isEmpty() || stall.name.contains(searchQuery, ignoreCase = true))
+            }
+            else -> false
+        }
+    }
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF0F0F0)) // Light gray background
     ) {
-        items(stalls) { stall ->
-            // Cast the stall to Identifiable
-            stallsScreenItem(navController = navController, stall = stall)
+        // Filtering Component
+        item {
+            StallFilterComponent(
+                navController = navController,
+                selectedCategory = selectedCategory,
+                categories = updatedCategories,
+                onCategorySelected = { category ->
+                    selectedCategory = category
+                },
+                searchQuery = searchQuery,
+                onSearchQueryChange = { query ->
+                    searchQuery = query
+                }
+            )
+        }
+
+
+        // Stall Cards in a 2-column grid
+        items(filteredStalls.chunked(2)) {stallPair ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {stallPair.forEach { stall ->
+                stallsScreenItem(navController = navController, stall = stall, modifier = Modifier
+                    .weight(1f)
+                    .padding(8.dp))
+            }
+            }
+        }
+    }
+}
+
+
+
+
+@Composable
+fun stallsScreenItem(navController: NavController, stall: Identifiable, modifier: Modifier) {
+    when (stall) {
+        is Market1Stalls -> {
+            StallCard(
+                stallName = stall.name,
+                imageResId = stall.imageResId,
+                navController = navController,
+                identifier = stall.getIdentifier(),
+                modifier = modifier
+            )
+        }
+        is Market2Stalls -> {
+            StallCard(
+                stallName = stall.name,
+                imageResId = stall.imageResId,
+                navController = navController,
+                identifier = stall.getIdentifier(),
+                modifier = modifier
+            )
         }
     }
 }
 
 @Composable
-fun stallsScreenItem(navController: NavController, stall: Identifiable) {
-    when (stall) {
-        is Market1Stalls -> {
-            Box(
+fun StallCard(
+    stallName: String,
+    imageResId: Int,
+    navController: NavController,
+    identifier: Int,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        modifier = modifier
+//            .padding(8.dp)
+//            .fillMaxWidth()
+            .clickable { navController.navigate("StallDetail/$identifier") },
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.Center, // Centers content vertically
+            horizontalAlignment = Alignment.CenterHorizontally // Centers content horizontally
+        ) {
+            // Stall Image
+            Image(
+                painter = painterResource(id = imageResId),
+                contentDescription = stallName,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
+                    .height(140.dp)
                     .fillMaxWidth()
-                    .padding(4.dp)
-                    .clickable { navController.navigate("StallDetail/${stall.getIdentifier()}") } // Navigate to stall detail on click
-            ) {
-                Column(
-                    modifier = Modifier
-                        .background(Color.White)
-                        .padding(2.dp)
-                        .fillMaxWidth()
-                ) {
-                    Box {
-                        // Optionally include an image here
-                        /*
-                        Image(
-                            painter = painterResource(id = stall.id), // Use the resolved image resource
-                            contentDescription = stall.name, // Stall name as content description
-                            modifier = Modifier
-                                .height(120.dp)
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
-                        )
-                        */
+                    .clip(RoundedCornerShape(16.dp))
+            )
 
-                        TextButton(
-                            onClick = { navController.navigate("StallDetail/${stall.getIdentifier()}") }, // Navigate to stall detail
-                            modifier = Modifier.align(Alignment.BottomEnd)
-                        ) {
-                            Text(text = "View")
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Column(modifier = Modifier) {
-                        Text(
-                            text = stall.name, // Access name from Market1Stalls
-                            style = MaterialTheme.typography.bodyLarge,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = stall.category, // Access category from Market1Stalls
-                            style = MaterialTheme.typography.labelMedium
-                        )
-                    }
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Stall Name
+            Text(
+                text = stallName,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // View Products Button
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.BottomEnd
+            ) {
+                FilledTonalButton(onClick = { navController.navigate("StallDetail/$identifier") }) {
+                    Text("View Products")
                 }
             }
-        }
-
-        is Market2Stalls -> {
-            // Similar implementation for Market2Stalls
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(4.dp)
-                    .clickable { navController.navigate("StallDetail/${stall.getIdentifier()}") } // Navigate to stall detail on click
-            ) {
-                Column(
-                    modifier = Modifier
-                        .background(Color.White)
-                        .padding(2.dp)
-                        .fillMaxWidth()
-                ) {
-                    Box {
-                        TextButton(
-                            onClick = { navController.navigate("StallDetail/${stall.getIdentifier()}") }, // Navigate to stall detail
-                            modifier = Modifier.align(Alignment.BottomEnd)
-                        ) {
-                            Text(text = "View")
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Column(modifier = Modifier) {
-                        Text(
-                            text = stall.name, // Access name from Market2Stalls
-                            style = MaterialTheme.typography.bodyLarge,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = stall.category, // Access category from Market2Stalls
-                            style = MaterialTheme.typography.labelMedium
-                        )
-                    }
-                }
-            }
-        }
-
-        else -> {
-            // Handle the case for an unknown stall type if necessary
-            Log.w("StallsScreen", "Unknown stall type: ${stall::class.simpleName}")
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StallFilterComponent(
+    navController: NavController,
+    selectedCategory: String,
+    categories: List<String>,
+    onCategorySelected: (String) -> Unit,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit
+) {
+
+    var expanded by rememberSaveable { mutableStateOf(false) } // Controls dropdown visibility
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp) // Margin around the whole filter component
+    ) {
+        // Search Bar
+
+        // Category Selector
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .padding(bottom = 8.dp)
+                .border(
+                    width = 1.dp,
+                    color = Color(0xFFD1E5F4), // Light blue border color
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .background(Color(0xFFEAF4FB))
+                .clickable { expanded = true } // Open dropdown on click
+                .padding(16.dp) // Padding inside the Box
+
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween // Space between text and dropdown arrow
+            ) {
+                Text(text = selectedCategory, style = MaterialTheme.typography.bodyLarge) // Category Text
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = "Dropdown arrow",
+                    tint = MaterialTheme.colorScheme.primary
+                ) // Dropdown Arrow
+            }
+
+            // Dropdown Menu
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier
+                    .background(Color.White) // White background
+                    .border(1.dp, Color.Gray, RoundedCornerShape(8.dp)) // Add border
+                    .padding(8.dp) // Padding inside the dropdown
+            ) {
+                categories.forEach { category ->
+                    DropdownMenuItem(
+                        text = {
+                            Text(text = category)
+                        },
+                        onClick = {
+                            onCategorySelected(category) // Handle category selection
+                            expanded = false
+                        },
+                        modifier = Modifier.fillMaxWidth(), // Ensure it takes full width
+                    )
+                }
+            }
+        }
+        Row {
+            TextField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .border(
+                        width = 1.dp,
+                        color = Color(0xFFD1E5F4), // Light blue border color
+                        shape = RoundedCornerShape(8.dp)
+                    ),
+                placeholder = { Text("Search...", color = Color.Gray) },
+                shape = RoundedCornerShape(8.dp),
+                colors = TextFieldDefaults.textFieldColors(
+                    focusedIndicatorColor = MaterialTheme.colorScheme.primary,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    containerColor = Color(0xFFEAF4FB)
+                )
+            )
+
+        }
+    }
+}
+
+

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/screens/MarketCards.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/screens/MarketCards.kt
@@ -1,5 +1,6 @@
 package nz.ac.canterbury.seng303.lab2.screens
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -24,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import nz.ac.canterbury.seng303.lab2.viewmodels.StallViewModel
+
 
 @Composable
 fun MarketCard(
@@ -63,6 +65,7 @@ fun MarketCard(
             Spacer(modifier = Modifier.height(8.dp))
 
             Button(
+
                 onClick = {
                     stallViewModel.loadDefaultStallsIfNoneExist(marketId)
                     navController.navigate("AllStallsScreen/$marketId") },

--- a/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/viewmodels/StallViewModel.kt
+++ b/seng303-lab-2-reference-implementation/app/src/main/java/nz/ac/canterbury/seng303/lab2/viewmodels/StallViewModel.kt
@@ -18,6 +18,18 @@ class StallViewModel(private val stallStorage: Storage<out Identifiable>) : View
     val selectedStall: StateFlow<Identifiable?> = _selectedStall
     private val _stalls = MutableStateFlow<List<Identifiable>>(emptyList())
     val stalls: StateFlow<List<Identifiable>> get() = _stalls
+    private val _categories = MutableStateFlow<List<String>>(emptyList())
+    val categories: StateFlow<List<String>> = _categories
+    private val _stallByName = MutableStateFlow<Identifiable?>(null)
+    val stallByName: StateFlow<Identifiable?> = _stallByName
+
+    // Function to fetch stall by name and marketId
+    fun getStallByName(marketId: Int, stallName: String) = viewModelScope.launch {
+        // Collect the result from the storage, based on marketId
+        stallStorage.getStallByName(marketId, stallName).collect { fetchedStall ->
+            _stallByName.value = fetchedStall // Now the fetched stall can be Market1Stalls or Market2Stalls
+        }
+    }
 
     fun getStallById(stallId: Int?) = viewModelScope.launch {
         if (stallId != null) {
@@ -38,10 +50,22 @@ class StallViewModel(private val stallStorage: Storage<out Identifiable>) : View
         _stalls.emit(stalls)
     }
 
+    // Function to fetch categories by marketId
+    fun getStallCategories(marketId: Int) = viewModelScope.launch {
+        stallStorage.getCategories(marketId).collect { fetchedCategories ->
+            _categories.value = fetchedCategories
+        }
+    }
+//    fun getStallsCategory(marketId: Int?) = viewModelScope.launch {  {
+//        val categories = when (marketId) {
+//            1 -> Market1Stalls.getCategories(marketId)
+//            2 -> Market2Stalls.getCategories(marketId)
+//            else -> emptyList() // Handle invalid marketId
+//        }
+//    } }
     fun loadDefaultStallsIfNoneExist(marketId: Int) = viewModelScope.launch {
         // Fetch current stalls with the specified marketId
         val currentStalls = stallStorage.getAll(marketId).first()
-
         // Check if the current stalls list is empty
         if (currentStalls.isEmpty()) {
             Log.d("STALL_VIEW_MODEL", "Inserting default stalls...")


### PR DESCRIPTION
Implemented filtering on the market page, allowing users to filter stalls by category or by typing the stall's name. Enhanced the design of the grid by using cards, and the screen now supports landscape orientation. To save time, I copied and pasted the stalls for Market 1 to create Market 2, but fetching stalls works based on the market ID. There are separate files for Market1Stalls and Market2Stalls. This implementation ensures that even if the stalls for both markets are different, I can still fetch the correct data using the respective market IDs.